### PR TITLE
Fixed typo in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Please note that `/examples` are not included in this package.
 Alternatively, you can clone the repository from git's `main` branch:
 
 ```shell
-$ git clone https://github.com/deepmind/android_env/
+$ git clone https://github.com/deepmind/android_env.git
 $ cd android_env
 $ python3 setup.py install
 ```


### PR DESCRIPTION
clone github project by command line. 
we should use .git url instead of folder path.
so i would like to fix type issue on README file.